### PR TITLE
fix(a11y): blur active element before opening antd v3 modals + bump 3.0.18

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SyncMyCookie (V3)",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "A Chrome extension to synchronize cookies.",
   "manifest_version": 3,
   "minimum_chrome_version": "88",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-my-cookie",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "A Chrome extension to synchronize cookies.",
   "main": "index.js",
   "repository": "git@github.com:Andiedie/sync-my-cookie.git",

--- a/src/components/console/console.tsx
+++ b/src/components/console/console.tsx
@@ -133,6 +133,13 @@ class Console extends Component<Prop, State> {
     const options = _.uniq(cookies.map((cookie) => cookie.name as string)).map((name) => {
       return <Select.Option key={name}>{name}</Select.Option>;
     });
+    // Blur the trigger before opening the modal so antd v3 does not put
+    // aria-hidden on an ancestor of a focused element (Chrome 124+ a11y
+    // warning: 'Blocked aria-hidden on an element because its descendant
+    // retained focus').
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
     this.setState({
       configuring: true,
       options,

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -64,6 +64,12 @@ class Popup extends Component<{}, State> {
 
   private handleDomainClose = (domain: string) => {
     const that = this;
+    // Blur the currently focused element before opening the modal so antd v3
+    // does not put aria-hidden on an ancestor of a focused descendant
+    // (Chrome 124+ accessibility warning).
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
     return new Promise<void>(((resolve) => {
       Modal.confirm({
         title: 'Delete',
@@ -105,6 +111,9 @@ class Popup extends Component<{}, State> {
   private handleMerge = async () => {
     const savedCookie = await gist.getCookies(this.state.currentDomain);
     await chromeUtils.importCookies(savedCookie);
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
     Modal.success({
       title: 'Merged',
       content: `${savedCookie.length} cookies merged`,
@@ -113,6 +122,9 @@ class Popup extends Component<{}, State> {
 
   private handlePush = async () => {
     const cookies = await chromeUtils.exportCookies(this.state.currentDomain);
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
     if (cookies.length === 0) {
       Modal.info({
         title: 'Cancelled',


### PR DESCRIPTION
## What

Fix Chrome 124+ accessibility warning:

> Blocked aria-hidden on an element because its descendant retained focus.

## Why

antd v3 sets `aria-hidden="true"` on the wrapper when a Modal is shown. If a descendant element (the trigger button or any element that retained focus) is still focused, Chrome flags the violation in the popup DevTools.

## How

Blur `document.activeElement` immediately before each `Modal.confirm/success/info` call and before opening the auto-push configuration modal. Minimal, behavior-preserving — no antd upgrade needed.

## Files

- `src/popup.tsx` — 3 modals (Delete confirm, Merged success, Push info/success)
- `src/components/console/console.tsx` — Configure Auto Push modal

## Version

Bump `3.0.17 → 3.0.18` so the release workflow can produce a tagged release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 3.0.18

* **Bug Fixes**
  * Improved focus behavior when opening modal dialogs to enhance accessibility and compatibility across browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->