### PR TITLE
fix(a11y): blur active element in options + setting modals + bump 3.0.20

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SyncMyCookie (V3)",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "description": "A Chrome extension to synchronize cookies.",
   "manifest_version": 3,
   "minimum_chrome_version": "88",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-my-cookie",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "description": "A Chrome extension to synchronize cookies.",
   "main": "index.js",
   "repository": "git@github.com:Andiedie/sync-my-cookie.git",

--- a/src/components/setting/setting.tsx
+++ b/src/components/setting/setting.tsx
@@ -193,6 +193,13 @@ class Setting extends Component<Prop, State> {
     try {
       await kevastGist.init();
     } catch (err) {
+      // Blur the currently focused element before opening the modal so antd v3
+      // does not put aria-hidden on an ancestor of a focused descendant
+      // (Chrome 124+ accessibility warning: 'Blocked aria-hidden on an element
+      // because its descendant retained focus').
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
       Modal.error({
         title: 'Fail',
         // @ts-ignore

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -17,6 +17,13 @@ class Options extends Component {
     );
   }
   private handleSet = () => {
+    // Blur the currently focused element before opening the modal so antd v3
+    // does not put aria-hidden on an ancestor of a focused descendant
+    // (Chrome 124+ accessibility warning: 'Blocked aria-hidden on an element
+    // because its descendant retained focus').
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
     Modal.success({
       title: 'Saved',
       onOk() {


### PR DESCRIPTION
## What

Chrome 124+ still logs the `Blocked aria-hidden on an element because its descendant retained focus` warning, this time from `options.html` (the Settings page).

## Why

The 3.0.18 popup-only fix did not cover:
- `src/options.tsx` → `Modal.success` (Saved confirmation after onSet)
- `src/components/setting/setting.tsx` → `Modal.error` (when KevastGist init fails)

## How

Apply the same minimal blur-before-modal pattern (calls `document.activeElement.blur()` right before the antd v3 Modal opens) so the focused element leaves the soon-to-be `aria-hidden="true"` subtree.

## Version

Bump `3.0.19 → 3.0.20` to ship the rebuilt extension.