### PR TITLE
chore(phase2/step4): upgrade TypeScript 4.1 -> 5.9

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SyncMyCookie (V3)",
-  "version": "3.0.25",
+  "version": "3.0.26",
   "description": "A Chrome extension to synchronize cookies.",
   "manifest_version": 3,
   "minimum_chrome_version": "88",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-my-cookie",
-  "version": "3.0.25",
+  "version": "3.0.26",
   "description": "A Chrome extension to synchronize cookies.",
   "main": "index.js",
   "repository": "git@github.com:Andiedie/sync-my-cookie.git",
@@ -59,7 +59,7 @@
     "tslint": "^5.12.1",
     "tslint-react": "^3.6.0",
     "ts-loader": "^9.5.2",
-    "typescript": "4.1.6",
+    "typescript": "^5.7.2",
     "webpack": "^5.99.9",
     "webpack-bundle-analyzer": "^3.0.4",
     "webpack-cli": "^5.1.4",

--- a/src/components/console/console.tsx
+++ b/src/components/console/console.tsx
@@ -170,14 +170,12 @@ class Console extends Component<Prop, State> {
   private handleAutoPushConfigClose = () => {
     this.setState({configuring: false});
   }
-  private handleAutoPushConfigChange =
-    async (value: string[], options: React.ReactElement<any> | Array<React.ReactElement<any>>) => {
-    if (options instanceof Array) {
-      const autoPushName = options
-        .filter((option) => typeof option.key === 'string')
-        .map((option) => option.key) as string[];
-      this.setState({autoPushName});
-    }
+  private handleAutoPushConfigChange = async (value: string[]) => {
+    // antd 5 Select<string[]> with mode='tags' returns the chosen tag
+    // strings directly in `value`, so we just persist that array.
+    // (antd v3/v4 used to pass ReactElement options here; we used to
+    // pull `option.key` out of them - the new API is simpler.)
+    this.setState({autoPushName: value});
   }
   private handlePush = async () => {
     this.setState({pushLoading: true});

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,7 +553,7 @@
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-transform-modules-systemjs@^7.29.0":
+"@babel/plugin-transform-modules-systemjs@^7.29.4":
   version "7.29.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz#f621105da99919c15cf4bde6fcc7346ef95e7b20"
   integrity sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==
@@ -799,9 +799,9 @@
     "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/preset-env@^7.25.0":
-  version "7.29.3"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.29.3.tgz#2bbd5b0162e6a762adfe356f4aecdef837a3d574"
-  integrity sha512-ySZypNLAIH1ClygLDQzVMoGQRViATnkHkYYV6TcNDz+8+jwZCdsguGvsb3EY5d9wyWyhmF1iSuFM0Yh5XPnqSA==
+  version "7.29.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.29.5.tgz#c48b7ed94582c8b685e21b8b42de8633ec289268"
+  integrity sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==
   dependencies:
     "@babel/compat-data" "^7.29.3"
     "@babel/helper-compilation-targets" "^7.28.6"
@@ -842,7 +842,7 @@
     "@babel/plugin-transform-member-expression-literals" "^7.27.1"
     "@babel/plugin-transform-modules-amd" "^7.27.1"
     "@babel/plugin-transform-modules-commonjs" "^7.28.6"
-    "@babel/plugin-transform-modules-systemjs" "^7.29.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.29.4"
     "@babel/plugin-transform-modules-umd" "^7.27.1"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.29.0"
     "@babel/plugin-transform-new-target" "^7.27.1"
@@ -5360,10 +5360,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.1.6:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
-  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
+typescript@^5.7.2:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 undici-types@~6.21.0:
   version "6.21.0"


### PR DESCRIPTION
## Phase 2 step 4

From the deferred Phase 2 plan (`memory/2026-05-05.md`). Skipping step 7 (less 3 -> 4) because step 2b already removed less entirely.

### Bumps
- `typescript`: `4.1.6` (2020-12) -> `^5.7.2` (resolves to 5.9.x at install time).

### Why now

`@types/node@22`, `@types/lodash`, antd 5's transitive `@ant-design/cssinjs` and `@rc-component/*` declaration files use syntax (template literal types, modern conditional types) that TS 4.1 cannot even parse, so plain `tsc --noEmit` was emitting 50+ `TS1005` errors in `node_modules`. The build still worked because `ts-loader` runs with `transpileOnly: true`, but any IDE/CI type-check was effectively useless.

### Migration

- `package.json`: `typescript` `4.1.6` -> `^5.7.2`.
- No `tsconfig.json` changes needed: `target: es5`, `module: esnext`, `moduleResolution: node`, `strict: true`, `downlevelIteration: true`, `isolatedModules: true` all still work the same in TS 5.9.

### Real source-code TS error revealed by the upgrade

`src/components/console/console.tsx` line 173: `handleAutoPushConfigChange(value: string[], options: ReactElement | ReactElement[])` used the antd v3/v4 `Select` onChange signature (the second arg used to be the rendered `<Option>` ReactElements). antd 5 `Select` onChange now passes `DefaultOptionType | DefaultOptionType[] | undefined` instead. We never actually needed the option list — for a `mode='tags'` select, the chosen tag strings are already in `value`. Replaced with a single-arg handler that just calls `this.setState({ autoPushName: value })`. Functionally identical.

### Verification
- `tsc --noEmit` is now CLEAN (0 errors), down from 50+ errors in `node_modules` + 1 real error in `src/`.
- webpack production build still compiles cleanly (3 perf-size warnings only). No bundle-size change.

### Bump
`3.0.25` -> `3.0.26`.

### Test plan after preview build
- Load extension. Popup must render.
- Open Configure Auto Push: type new tag(s), tick Auto Push, save -> reload extension -> the saved tag list must come back. (This exercises the rewritten handler.)
- Push / Merge / Delete domain / Save settings flows still work.
- DevTools Console: clean (just the antd 5 deprecation about static `message`/`Modal` is acceptable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented extension version to 3.0.26 to mark the latest release cycle
  * Upgraded TypeScript development dependency from version 4.1.6 to 5.7.2 to leverage modern language features, improved type checking, and enhanced development tooling

* **Bug Fixes**
  * Resolved auto-push configuration selection behavior to ensure proper compatibility with recent updates to the underlying component library functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->