### PR TITLE
chore(phase2/step9): replace react-textfit with custom TextFit

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SyncMyCookie (V3)",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "description": "A Chrome extension to synchronize cookies.",
   "manifest_version": 3,
   "minimum_chrome_version": "88",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-my-cookie",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "description": "A Chrome extension to synchronize cookies.",
   "main": "index.js",
   "repository": "git@github.com:Andiedie/sync-my-cookie.git",
@@ -53,7 +53,6 @@
     "postcss-preset-env": "^6.5.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "react-textfit": "^1.1.0",
     "sass-loader": "^16.0.5",
     "style-loader": "^4.0.0",
     "tslint": "^5.12.1",

--- a/src/components/console/console.tsx
+++ b/src/components/console/console.tsx
@@ -8,7 +8,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { auto, AutoConfiguration, gist } from '../../utils/store';
-const { Textfit } = require('react-textfit');
+import TextFit from '../text-fit/text-fit';
 
 import _ from 'lodash';
 
@@ -44,12 +44,12 @@ class Console extends Component<Prop, State> {
     if (this.props.domain) {
       return (
         <div className={style.wrapper}>
-          <Textfit
+          <TextFit
             className={style.domain}
             max={40}
           >
             {this.props.domain}
-          </Textfit>
+          </TextFit>
           <div className={style.sliders}>
             <div className={style.one}>
               <div className={style.secret}>

--- a/src/components/text-fit/text-fit.tsx
+++ b/src/components/text-fit/text-fit.tsx
@@ -1,0 +1,111 @@
+import React, { Component, createRef } from 'react';
+
+interface Prop {
+  max: number;
+  min?: number;
+  className?: string;
+  children: React.ReactNode;
+}
+
+interface State {
+  fontSize: number;
+}
+
+/**
+ * Lightweight drop-in replacement for `react-textfit` (single-line mode).
+ *
+ * `react-textfit@1.1.1` is unmaintained (last release 2018) and declares
+ * peer deps `react@^15.0.0 || ^16.0.0`, which is why yarn keeps emitting
+ * peer warnings against React 18. It also relies on legacy `findDOMNode`
+ * APIs that React is removing.
+ *
+ * This component uses `ResizeObserver` + a small binary search to shrink
+ * the font size until the inner text fits the parent's width on a single
+ * line. Behavior matches how the app used `<Textfit max={40}>{domain}</Textfit>`.
+ */
+class TextFit extends Component<Prop, State> {
+  private wrapperRef = createRef<HTMLDivElement>();
+  private innerRef = createRef<HTMLSpanElement>();
+  private observer: ResizeObserver | null = null;
+
+  public state: State = {
+    fontSize: this.props.max,
+  };
+
+  public componentDidMount() {
+    this.fit();
+    if (typeof ResizeObserver !== 'undefined' && this.wrapperRef.current) {
+      this.observer = new ResizeObserver(() => this.fit());
+      this.observer.observe(this.wrapperRef.current);
+    }
+  }
+
+  public componentDidUpdate(prevProps: Prop) {
+    if (prevProps.children !== this.props.children || prevProps.max !== this.props.max) {
+      this.fit();
+    }
+  }
+
+  public componentWillUnmount() {
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+  }
+
+  private fit = () => {
+    const wrapper = this.wrapperRef.current;
+    const inner = this.innerRef.current;
+    if (!wrapper || !inner) {
+      return;
+    }
+    const max = this.props.max;
+    const min = this.props.min ?? 4;
+    const targetWidth = wrapper.clientWidth;
+    if (targetWidth <= 0) {
+      return;
+    }
+    // Binary search the largest font-size (in px) that keeps the text
+    // within `targetWidth`. We mutate the element's inline font-size
+    // directly during the search to read scrollWidth at each step.
+    let lo = min;
+    let hi = max;
+    let best = min;
+    while (lo <= hi) {
+      const mid = Math.floor((lo + hi) / 2);
+      inner.style.fontSize = `${mid}px`;
+      if (inner.scrollWidth <= targetWidth) {
+        best = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    if (this.state.fontSize !== best) {
+      this.setState({ fontSize: best });
+    } else {
+      // Reset inline style so React can drive font-size through state
+      // on the next render.
+      inner.style.fontSize = `${best}px`;
+    }
+  }
+
+  public render() {
+    return (
+      <div ref={this.wrapperRef} className={this.props.className}>
+        <span
+          ref={this.innerRef}
+          style={{
+            fontSize: `${this.state.fontSize}px`,
+            display: 'inline-block',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {this.props.children}
+        </span>
+      </div>
+    );
+  }
+}
+
+export default TextFit;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3487,7 +3487,7 @@ lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -3704,11 +3704,6 @@ num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
   integrity sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==
-
-object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-inspect@^1.13.3, object-inspect@^1.13.4:
   version "1.13.4"
@@ -4294,20 +4289,6 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.10:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
-
-prop-types@^15.7.2:
-  version "15.8.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
-  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.13.1"
-
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -4716,23 +4697,10 @@ react-dom@^18.3.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react-is@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
 react-is@^18.2.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
-
-react-textfit@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-textfit/-/react-textfit-1.1.1.tgz#cce3d974c69b8b4222cfae78200abc366f74d050"
-  integrity sha512-UDSQRo5yBEGueLTE5SgNV9fSmr5CWJkE0E0R0YbcbCO69iuJGfcT6wspKhX2sIwdsDyT9qXOwMC80cnRolir7Q==
-  dependencies:
-    process "^0.11.10"
-    prop-types "^15.7.2"
 
 react@^18.3.0:
   version "18.3.1"


### PR DESCRIPTION
## Phase 2 step 9

From the deferred Phase 2 plan (`memory/2026-05-05.md`). Drops the unmaintained `react-textfit` package in favour of a small in-tree component.

### Why

`react-textfit@1.1.1` was last released in 2018 and declares `peer: react@^15.0.0 || ^16.0.0`. After the React 18 upgrade in step 1 it has been emitting yarn peer warnings. It also leans on `findDOMNode`, which React strongly discourages and may remove in a future major.

It was used in exactly one place: the popup's domain header in `src/components/console/console.tsx`, which renders the active domain string at a font size that shrinks to fit the container width.

### Replacement

Added `src/components/text-fit/text-fit.tsx` (~100 LOC). It uses `ResizeObserver` plus a small binary search on font-size to shrink the inner span until `scrollWidth <= clientWidth`. Keeps the same prop shape as `<Textfit max={40} className="...">` so the call site in `console.tsx` only changed the import.

### Verification
- `tsc --noEmit` still clean.
- Production build still compiles (3 perf-size warnings only).
- popup bundle: 824 KiB -> 820 KiB.
- The two `react-textfit has incorrect peer dependency "react"` warnings during `yarn install` are gone.

### Bump
`3.0.26` -> `3.0.27`.

### Test plan after preview build
- Load extension, open popup on a domain with a short name (e.g. `gmail.com`) -> domain header should be near max font.
- Open popup on a domain with a long name (e.g. `accounts.google.com`, `console.aws.amazon.com`) -> font should shrink to fit on a single line.
- Resize popup width if you can; the text should re-fit (driven by ResizeObserver).
- DevTools Console clean (only the antd 5 deprecation about static `message`/`Modal` is acceptable).
